### PR TITLE
chore: Disable targets for cross-compilation.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,6 +7,7 @@ project()
 cc_library(
     name = "hsbracket",
     srcs = ["src/hsbracket.c"],
+    tags = ["no-cross"],
     deps = ["//third_party/haskell:rts"],
     alwayslink = True,
 )
@@ -15,6 +16,7 @@ haskell_library(
     name = "c-toxcore-hs",
     srcs = ["src/Network/Tox/CExport/CryptoCore.hs"],
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     visibility = ["//tools/haskell:__pkg__"],
     deps = [
         ":hsbracket",
@@ -34,6 +36,7 @@ cc_test(
         "test/crypto_core.h",
         "test/test-program.c",
     ],
+    tags = ["no-cross"],
     deps = [
         ":c-toxcore-hs",
     ],


### PR DESCRIPTION
This way we can do bazel build //... when cross-compiling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/c-toxcore-hs/23)
<!-- Reviewable:end -->
